### PR TITLE
Fix: allow plugin to load on Xcode5 DP3

### DIFF
--- a/CedarShortcuts/Info.plist
+++ b/CedarShortcuts/Info.plist
@@ -24,6 +24,10 @@
 	<true/>
 	<key>XCPluginHasUI</key>
 	<false/>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>63FC1C47-140D-42B0-BB4D-A10B2D225574</string>
+	</array>
 	<key>XC4Compatible</key>
 	<true/>
 </dict>


### PR DESCRIPTION
When launching Xcode5 DP3, plugins won't load without this setting.
