### PR TITLE
Xcode5 DP3 Fix: lastActiveWorkspaceWindow method no longer exists

### DIFF
--- a/CedarShortcuts/CDRSFilePathNavigator.m
+++ b/CedarShortcuts/CDRSFilePathNavigator.m
@@ -20,7 +20,7 @@
     documentURL:(id)url
     usingBlock:(id)block;
 
-- (id)lastActiveWorkspaceWindow;
+- (id)lastActiveWorkspaceWindowController;
 - (id)windowController;
 - (id)workspace;
 - (id)document;
@@ -64,8 +64,7 @@
 }
 
 + (id)_currentEditorArea {
-    id window = [NSClassFromString(@"IDEWorkspaceWindow") lastActiveWorkspaceWindow];
-    id workspaceWindowController = [window windowController];
+    id workspaceWindowController = [NSClassFromString(@"IDEWorkspaceWindow") lastActiveWorkspaceWindowController];
     return [workspaceWindowController editorArea];
 }
 @end


### PR DESCRIPTION
My previous pull request allowed the plugin to load, however it crashes whenever the plugin attempts to get the current editor area because -[IDEWorkspaceWindow lastActiveWorkspaceWindow] no longer exists.

This pull request uses -[IDEWorkspaceWindow lastActiveWorkspaceWindowController] instead, since the window was only needed to obtain the controller.  It seems like this method is also available in Xcode 4.6.2, but I wasn't able to verify if it is present in older versions.
