### PR TITLE
Set 'rake install' as the default task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,7 @@ def system_or_exit(cmd, stdout = nil)
   system(cmd) or raise "******** Build failed ********"
 end
 
+task :default => :install
 desc "Build & install"
 task :install => :clean do
   system_or_exit <<-BASH, output_file("install")


### PR DESCRIPTION
Seemed like a reasonable thing since every time I clone CedarShortcuts I just want to install, and I forget that there isn't a default rake task, but feel free to ignore / close if you disagree.

While I'm typing these words, I just wanted to say that this project is awesome. Saves a ton of time when I'm looking at cedar test failures. Thank you so much for open sourcing this!
