### PR TITLE
Use currentEditor vs. currentSourceEditor. 

### DIFF
--- a/CedarShortcuts/CDRSEditMenu.m
+++ b/CedarShortcuts/CDRSEditMenu.m
@@ -7,7 +7,7 @@
 - (void)insertImport:(id)sender {
     CDRSInsertImport *insertImporter =
         [[[CDRSInsertImport alloc]
-            initWithEditor:CDRSXcode.currentSourceCodeEditor] autorelease];
+            initWithEditor:[CDRSXcode currentEditor]] autorelease];
     [insertImporter insertImport];
 }
 

--- a/CedarShortcuts/CDRSRunFocused.m
+++ b/CedarShortcuts/CDRSRunFocused.m
@@ -63,7 +63,7 @@
 }
 
 - (long long)_currentLineNumber {
-    return CDRSXcode.currentSourceCodeEditor._currentOneBasedLineNubmer;
+    return [[CDRSXcode currentEditor] _currentOneBasedLineNumber];
 }
 
 #pragma mark - Last focused run path

--- a/CedarShortcuts/CDRSShowRecentFiles.m
+++ b/CedarShortcuts/CDRSShowRecentFiles.m
@@ -6,7 +6,7 @@
 
 - (void)showMenu {
     XC(IDEEditorContext) editorContext =
-        CDRSXcode.currentSourceCodeEditor.editorContext;
+        [[CDRSXcode currentEditor] editorContext];
     NSView *relatedItems = [(id)editorContext valueForKey:@"_relatedItemsPopUpButton"];
 
     [self._recentsMenu
@@ -47,7 +47,7 @@
     NSString *filePath = [url.absoluteString stringByReplacingOccurrencesOfString:@"file://localhost" withString:@""];
 
     XC(IDEEditorContext) editorContext =
-        CDRSXcode.currentSourceCodeEditor.editorContext;
+        [[CDRSXcode currentEditor] editorContext];
     [CDRSFilePathNavigator
         openFilePath:filePath
         lineNumber:NSNotFound

--- a/CedarShortcuts/CDRSXcodeInterfaces.h
+++ b/CedarShortcuts/CDRSXcodeInterfaces.h
@@ -100,5 +100,5 @@
 - (XC(IDESourceCodeDocument))sourceCodeDocument;
 - (XC(DVTSourceExpression))_expressionAtCharacterIndex:(NSRange)range;
 - (NSArray *)currentSelectedDocumentLocations;
-- (long long)_currentOneBasedLineNubmer;
+- (long long)_currentOneBasedLineNumber;
 @end


### PR DESCRIPTION
Fixed typo in _currentOneBasedLineNubmer. 
Previously did not compile:

The following build commands failed:
	CompileC build/CedarShortcuts.build/Release/CedarShortcuts.build/Objects-normal/x86_64/CDRSRunFocused.o CedarShortcuts/CDRSRunFocused.m normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.compiler
	CompileC build/CedarShortcuts.build/Release/CedarShortcuts.build/Objects-normal/x86_64/CDRSEditMenu.o CedarShortcuts/CDRSEditMenu.m normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.compiler
(2 failures)
rake aborted!