### PR TITLE
Allow importing symbol under cursor from beginning of symbol

### DIFF
--- a/CedarShortcuts/CDRSInsertImport.m
+++ b/CedarShortcuts/CDRSInsertImport.m
@@ -54,7 +54,14 @@
         self.editor.currentSelectedDocumentLocations.lastObject;
     NSUInteger cursorIndex = currentLocation.characterRange.location;
     NSUInteger expressionIndex = [self.textStorage nextExpressionFromIndex:cursorIndex forward:NO];
-    return [self.editor _expressionAtCharacterIndex:NSMakeRange(expressionIndex, 0)].symbolString;
+
+    id symbol = [self.editor _expressionAtCharacterIndex:NSMakeRange(expressionIndex, 0)].symbolString;
+    if (symbol == nil) {
+        expressionIndex = [self.textStorage nextExpressionFromIndex:cursorIndex forward:YES];
+        symbol = [self.editor _expressionAtCharacterIndex:NSMakeRange(expressionIndex, 0)].symbolString;
+    }
+
+    return symbol;
 }
 
 - (NSString *)_importDeclaration:(NSString *)symbol {


### PR DESCRIPTION
Previously, if you had your cursor at the beginning of a symbol, then typing cmd+opt+i would add `import "(null).h"` because of a nil pointer.

This pull request attempts to fix this by looking forward for a symbol, and then falls back to looking backward. It should probably gracefully fail if no symbol could be found, but this PR does not address that case.

Many props to @stansey for authoring this fix originally.