### PR TITLE
Add a shortcut to focus or unfocus a spec

### DIFF
--- a/CedarShortcuts.xcodeproj/project.pbxproj
+++ b/CedarShortcuts.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		96C2110216B619B30088393E /* CDRSSchemePicker.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C2110116B619B30088393E /* CDRSSchemePicker.m */; };
 		96CADEC01626A78700A0B674 /* CDRSUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 96CADEBF1626A78700A0B674 /* CDRSUtils.m */; };
 		96DB4E4316227C4E00743C95 /* CDRSXcode.m in Sources */ = {isa = PBXBuildFile; fileRef = 96DB4E4216227C4E00743C95 /* CDRSXcode.m */; };
+		AE6599191B03E07B0071CDD8 /* CDRSFocusUnfocusSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = AE6599181B03E07B0071CDD8 /* CDRSFocusUnfocusSpec.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -77,6 +78,8 @@
 		96DB4E4116227C4E00743C95 /* CDRSXcode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDRSXcode.h; sourceTree = "<group>"; };
 		96DB4E4216227C4E00743C95 /* CDRSXcode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDRSXcode.m; sourceTree = "<group>"; };
 		96FF419916060A3300B461B4 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
+		AE6599171B03E07B0071CDD8 /* CDRSFocusUnfocusSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDRSFocusUnfocusSpec.h; sourceTree = "<group>"; };
+		AE6599181B03E07B0071CDD8 /* CDRSFocusUnfocusSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDRSFocusUnfocusSpec.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -118,6 +121,8 @@
 				96593EE616226AA1009C7979 /* CDRSInsertImport.m */,
 				966A685A16465960005D28B7 /* CDRSShowRecentFiles.h */,
 				966A685B16465960005D28B7 /* CDRSShowRecentFiles.m */,
+				AE6599171B03E07B0071CDD8 /* CDRSFocusUnfocusSpec.h */,
+				AE6599181B03E07B0071CDD8 /* CDRSFocusUnfocusSpec.m */,
 			);
 			name = Actions;
 			sourceTree = "<group>";
@@ -253,7 +258,7 @@
 		960FA0861605819F00923A87 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0450;
+				LastUpgradeCheck = 0630;
 			};
 			buildConfigurationList = 960FA0891605819F00923A87 /* Build configuration list for PBXProject "CedarShortcuts" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -281,6 +286,7 @@
 				960FA0A2160584AC00923A87 /* CedarShortcuts.m in Sources */,
 				9677A43D1612C65200A4708D /* NSObject+CDRSChainSelector.m in Sources */,
 				9677A4401612C6D700A4708D /* IDELaunchSession_CDRSCustomize.m in Sources */,
+				AE6599191B03E07B0071CDD8 /* CDRSFocusUnfocusSpec.m in Sources */,
 				960985CA1613105500BFBE51 /* CDRSRunFocused.m in Sources */,
 				9646DDEE161D435F00AAF79C /* CDRSRunFocusedMenu.m in Sources */,
 				22EE4BC9161F3DD200A0FAFE /* CDRSOpenAlternateMenu.m in Sources */,

--- a/CedarShortcuts/CDRSEditMenu.m
+++ b/CedarShortcuts/CDRSEditMenu.m
@@ -1,6 +1,7 @@
 #import "CDRSEditMenu.h"
 #import "CDRSInsertImport.h"
 #import "CDRSXcode.h"
+#import "CDRSFocusUnfocusSpec.h"
 
 @implementation CDRSEditMenu
 
@@ -11,10 +12,17 @@
     [insertImporter insertImport];
 }
 
+- (void)focusSpecUnderCursor:(id)sender {
+    id editor = [CDRSXcode currentEditor];
+    CDRSFocusUnfocusSpec *specFocuser = [[[CDRSFocusUnfocusSpec alloc] initWithEditor:editor] autorelease];
+    [specFocuser focusOrUnfocusSpec];
+}
+
 - (void)attach {
     NSMenu *editMenu = [CDRSXcode menuWithTitle:@"Edit"];
     [editMenu addItem:NSMenuItem.separatorItem];
     [editMenu addItem:self._insertImportItem];
+    [editMenu addItem:self._focusSpecItem];
 }
 
 #pragma mark - Menu items
@@ -26,6 +34,16 @@
     item.action = @selector(insertImport:);
     item.keyEquivalent = @"i";
     item.keyEquivalentModifierMask = NSControlKeyMask | NSAlternateKeyMask;
+    return item;
+}
+
+- (NSMenuItem *)_focusSpecItem {
+    NSMenuItem *item = [[[NSMenuItem alloc] init] autorelease];
+    item.title = @"Focus spec under cursor";
+    item.target = self;
+    item.action = @selector(focusSpecUnderCursor:);
+    item.keyEquivalent = @"f";
+    item.keyEquivalentModifierMask = NSControlKeyMask;
     return item;
 }
 @end

--- a/CedarShortcuts/CDRSFocusUnfocusSpec.h
+++ b/CedarShortcuts/CDRSFocusUnfocusSpec.h
@@ -1,0 +1,10 @@
+#import "CDRSXcodeInterfaces.h"
+
+@interface CDRSFocusUnfocusSpec : NSObject {
+    XC(IDESourceCodeEditor) _editor;
+    XC(DVTSourceTextStorage) _textStorage;
+}
+
+- (id)initWithEditor:(XC(IDESourceCodeEditor))editor;
+- (void)focusOrUnfocusSpec;
+@end

--- a/CedarShortcuts/CDRSFocusUnfocusSpec.m
+++ b/CedarShortcuts/CDRSFocusUnfocusSpec.m
@@ -1,0 +1,81 @@
+#import "CDRSFocusUnfocusSpec.h"
+#import "CDRSAlert.h"
+
+@interface CDRSFocusUnfocusSpec ()
+@property (nonatomic, retain) XC(IDESourceCodeEditor) editor;
+@property (nonatomic, retain) XC(DVTSourceTextStorage) textStorage;
+@end
+
+@implementation CDRSFocusUnfocusSpec
+
+@synthesize editor = _editor;
+@synthesize textStorage = _textStorage;
+
+- (id)initWithEditor:(XC(IDESourceCodeEditor))editor {
+    if (self = [super init]) {
+        self.editor = editor;
+        self.textStorage = self.editor.sourceCodeDocument.textStorage;
+    }
+    return self;
+}
+
+- (void)dealloc {
+    self.editor = nil;
+    self.textStorage = nil;
+    [super dealloc];
+}
+
+- (void)focusOrUnfocusSpec {
+    XC(DVTTextDocumentLocation) currentLocation = self.editor.currentSelectedDocumentLocations.firstObject;
+    NSUInteger i = currentLocation.characterRange.location;
+
+    for (NSUInteger index = i; index > 0; --index) {
+        id <XCP(DVTSourceExpression)> expression = [self previousExpressionAtIndex:index];
+        NSString *symbol = expression.symbolString;
+        NSUInteger location = expression.expressionRange.location;
+
+        if ([self isCedarFunction:symbol]) {
+            [self addFocusToSymbol:symbol AtIndex:location];
+            return;
+        } else if ([self isFocusedCedarFunction:symbol]) {
+            [self removeFocusFromSymbol:symbol AtIndex:location];
+            return;
+        }
+    }
+}
+
+#pragma mark - Private
+
+- (id <XCP(DVTSourceExpression)>)previousExpressionAtIndex:(NSUInteger)index {
+    NSUInteger expressionIndex = [self.textStorage nextExpressionFromIndex:index forward:NO];
+    return [self.editor _expressionAtCharacterIndex:NSMakeRange(expressionIndex, 0)];
+}
+
+#pragma mark - Identifying Cedar functions
+
+- (BOOL)isCedarFunction:(NSString *)symbolName {
+    NSArray *functionNames = @[@"it", @"describe", @"context"];
+    return [functionNames indexOfObject:symbolName] != NSNotFound;
+}
+
+- (BOOL)isFocusedCedarFunction:(NSString *)symbolName {
+    return [self isCedarFunction:[symbolName substringFromIndex:1]];
+}
+
+#pragma mark - Document editing
+
+- (void)addFocusToSymbol:(NSString *)symbol AtIndex:(NSUInteger)index {
+    id undoManager = [(id)self.editor.sourceCodeDocument valueForKey:@"_dvtUndoManager"];
+    [self.textStorage replaceCharactersInRange:NSMakeRange(index, symbol.length)
+                                    withString:[NSString stringWithFormat:@"f%@", symbol]
+                               withUndoManager:undoManager];
+}
+
+- (void)removeFocusFromSymbol:(NSString *)symbol AtIndex:(NSUInteger)index {
+    id undoManager = [(id)self.editor.sourceCodeDocument valueForKey:@"_dvtUndoManager"];
+    [self.textStorage replaceCharactersInRange:NSMakeRange(index, symbol.length)
+                                    withString:[symbol substringFromIndex:1]
+                               withUndoManager:undoManager];
+}
+
+@end

--- a/CedarShortcuts/CDRSXcodeInterfaces.h
+++ b/CedarShortcuts/CDRSXcodeInterfaces.h
@@ -64,6 +64,7 @@
 
 @protocol XCP(DVTSourceExpression)
 - (NSString *)symbolString;
+- (NSRange)expressionRange;
 @end
 
 @protocol XCP(DVTSourceLandmarkItem)


### PR DESCRIPTION
This is not a *beautiful* bit of code, but I think it is quite functional.
I've often been annoyed by how I need to move my cursor to the EXACT right
location in my specs in order to focus a few tests. This shortcut allows users
to either focus, or unfocus the example under their cursor with a simple keystroke.
I chose ctrl+f, but there might be a better keybinding.

I had to add some funky code to work around an edgecase when the cursor is
inside the word "it" or "describe" or "context", but other than that, I think
this is pretty straightforward. I looked around at some of the classdumped headers
for XC classes, but couldn't find anything that would make this easier to implement.

Any suggestions for improving this code would be greatly appreciated.