### PR TITLE
Fixes the detection of existing imports

### DIFF
--- a/CedarShortcuts/CDRSInsertImport.m
+++ b/CedarShortcuts/CDRSInsertImport.m
@@ -7,6 +7,9 @@
 @end
 
 @implementation CDRSInsertImport
+
+static NSString * const importDeclarationFormatString = @"import \"%@.h\"";
+
 @synthesize
     editor = _editor,
     textStorage = _textStorage;
@@ -41,7 +44,7 @@
 #pragma mark - Import declaration
 
 - (BOOL)_isSymbolImported:(NSString *)symbol {
-    NSString *fullSymbol = [NSString stringWithFormat:@"%@.h", symbol];
+    NSString *fullSymbol = [NSString stringWithFormat:importDeclarationFormatString, symbol];
     for (XC(DVTSourceLandmarkItem) importLocation in self.textStorage.importLandmarkItems) {
         if ([importLocation.name rangeOfString:fullSymbol].location != NSNotFound)
             return YES;
@@ -65,7 +68,8 @@
 }
 
 - (NSString *)_importDeclaration:(NSString *)symbol {
-    return [NSString stringWithFormat:@"#import \"%@.h\"\n", symbol];
+    NSString *importDeclaration = [NSString stringWithFormat:importDeclarationFormatString, symbol];
+    return [NSString stringWithFormat:@"#%@\n", importDeclaration];
 }
 
 #pragma mark - Document editing


### PR DESCRIPTION
Given a scenario such as this:

```objective-c
FooBar *fooBar = [[FooBar alloc] init];
Bar *bar = [[Bar alloc] init];
```

Prior to this change, if someone used `ctrl+option+i` to import
`FooBar` and *then* `Bar`, then the `FooBar` import would erroneously be
detected as an existing import for `Bar`.

This change tightens the search criteria, reducing the possibility of
false positives for duplicate detection.