### PR TITLE
Fix crash when invoking 'run focused spec' menu items

### DIFF
--- a/CedarShortcuts/CDRSRunFocused.m
+++ b/CedarShortcuts/CDRSRunFocused.m
@@ -63,7 +63,12 @@
 }
 
 - (long long)_currentLineNumber {
-    return [[CDRSXcode currentEditor] _currentOneBasedLineNubmer];
+    id currentEditor = [CDRSXcode currentEditor];
+    if ([currentEditor respondsToSelector:@selector(_currentOneBasedLineNumber)]) {
+        return [currentEditor _currentOneBasedLineNumber];
+    } else {
+        return [currentEditor _currentOneBasedLineNubmer];
+    }
 }
 
 #pragma mark - Last focused run path

--- a/CedarShortcuts/CDRSXcodeInterfaces.h
+++ b/CedarShortcuts/CDRSXcodeInterfaces.h
@@ -100,5 +100,6 @@
 - (XC(IDESourceCodeDocument))sourceCodeDocument;
 - (XC(DVTSourceExpression))_expressionAtCharacterIndex:(NSRange)range;
 - (NSArray *)currentSelectedDocumentLocations;
-- (long long)_currentOneBasedLineNubmer;
+- (long long)_currentOneBasedLineNumber; // this selector was renamed at some unknown point
+- (long long)_currentOneBasedLineNubmer; // this typo definitely existed prior to xcode 6
 @end


### PR DESCRIPTION
Nubmer => Number

Unsure when this changed, my best guess is sometime around the release of Xcode 6.