### PR TITLE
Improve performance of focus / unfocus spec shortcut

### DIFF
--- a/CedarShortcuts/CDRSFocusUnfocusSpec.m
+++ b/CedarShortcuts/CDRSFocusUnfocusSpec.m
@@ -27,9 +27,14 @@
 
 - (void)focusOrUnfocusSpec {
     XC(DVTTextDocumentLocation) currentLocation = self.editor.currentSelectedDocumentLocations.firstObject;
-    NSUInteger i = currentLocation.characterRange.location;
+    NSUInteger index = currentLocation.characterRange.location;
 
-    for (NSUInteger index = i; index > 0; --index) {
+    if (index > self.textStorage.string.length) {
+        [CDRSAlert flashMessage:@"failed to find an 'it', 'describe', or 'context'"];
+        return;
+    }
+
+    while(index > 0) {
         id <XCP(DVTSourceExpression)> expression = [self previousExpressionAtIndex:index];
         NSString *symbol = expression.symbolString;
         NSUInteger location = expression.expressionRange.location;
@@ -40,6 +45,12 @@
         } else if ([self isFocusedCedarFunction:symbol]) {
             [self removeFocusFromSymbol:symbol AtIndex:location];
             return;
+        }
+
+        index = location - 1;
+        if (index > self.textStorage.string.length) {
+            [CDRSAlert flashMessage:@"failed to find an 'it', 'describe', or 'context'"];
+            break;
         }
     }
 }

--- a/CedarShortcuts/CDRSXcodeInterfaces.h
+++ b/CedarShortcuts/CDRSXcodeInterfaces.h
@@ -73,14 +73,15 @@
 @end
 
 @protocol XCP(DVTSourceTextStorage)
+- (NSString *)string;
 - (NSArray *)importLandmarkItems;
 
 - (NSUInteger)nextExpressionFromIndex:(unsigned long long)index
-    forward:(BOOL)forward;
+                              forward:(BOOL)forward;
 
 - (void)replaceCharactersInRange:(NSRange)range
-    withString:(NSString *)string
-    withUndoManager:(id)undoManager;
+                      withString:(NSString *)string
+                 withUndoManager:(id)undoManager;
 @end
 
 @protocol XCP(DVTTextDocumentLocation)


### PR DESCRIPTION
I had noticed that this was significantly slower on some iMacs at work, especially with realistic specs that have several hundred line top-level describes. This change looks backward by whole symbols at a time, rather than stepping back character by character.