### PR TITLE
Always show alternate file in adjacent editor

### DIFF
--- a/CedarShortcuts/CDRSFilePathNavigator.h
+++ b/CedarShortcuts/CDRSFilePathNavigator.h
@@ -1,20 +1,21 @@
 #import <Cocoa/Cocoa.h>
 
-@interface CDRSFilePathNavigator : NSObject 
+@interface CDRSFilePathNavigator : NSObject
 @end
 
 @interface CDRSFilePathNavigator (Editors)
 + (id)editorContextShowingFilePath:(NSString *)filePath;
 + (void)editorContext:(void(^)(id))editorContextBlock
-    forFilePath:(NSString *)filePath
-    adjacent:(BOOL)openAdjacent;
+          forFilePath:(NSString *)filePath
+             adjacent:(BOOL)openAdjacent;
 @end
 
 @interface CDRSFilePathNavigator (Navigation)
 + (void)openFilePath:(NSString *)filePath
-    lineNumber:(NSUInteger)lineNumber
-    inEditorContext:(id)editorContext;
+          lineNumber:(NSUInteger)lineNumber
+     inEditorContext:(id)editorContext;
 
 + (void)openAdjacentEditorContextTo:(id)editorContext
-    callback:(void(^)(id))editorContextBlock;
+                           callback:(void(^)(id))editorContextBlock
+                        documentURL:(NSString *)documentURL;
 @end

--- a/CedarShortcuts/CDRSFilePathNavigator.m
+++ b/CedarShortcuts/CDRSFilePathNavigator.m
@@ -49,7 +49,7 @@
     id lastEditorContext = [editorArea lastActiveEditorContext];
 
     if (openAdjacent) {
-        [self openAdjacentEditorContextTo:lastEditorContext callback:editorContextBlock];
+        [self openAdjacentEditorContextTo:lastEditorContext callback:editorContextBlock documentURL:filePath];
     } else editorContextBlock(lastEditorContext);
 }
 
@@ -89,12 +89,13 @@
 }
 
 + (void)openAdjacentEditorContextTo:(id)editorContext
-    callback:(void(^)(id))editorContextBlock {
+                           callback:(void(^)(id))editorContextBlock
+                        documentURL:(NSString *)documentURL {
 
     [NSClassFromString(@"IDEEditorCoordinator")
         _doOpenIn_AdjacentEditor_withWorkspaceTabController:nil
         editorContext:editorContext
-        documentURL:nil
+        documentURL:documentURL
         usingBlock:editorContextBlock];
 }
 @end


### PR DESCRIPTION
Starting in Xcode 6.3 (or maybe earlier?), the "open alternate" shortcut regressed.

Expected :

* User is editing Foo.m
* User activates "open alternate in adjacent" shortcut
* FooSpec.mm appears in adjacent editor

Actual :

* FooSpec.mm briefly appears in adjacent editor, but is then replaced by some other random file

I believe this occurs because we never passed along the correct document for the adjacent
editor to display. Starting in Xcode 6 there was a concept of a "fallback" document for
the IDEEditorCoordinator class, and it seems that the editor will fallback to the previous
open document if one is not provided here.