### PR TITLE
add plug-in compatibility UUID for Xcode 7.2

### DIFF
--- a/CedarShortcuts/Info.plist
+++ b/CedarShortcuts/Info.plist
@@ -32,6 +32,7 @@
 		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
 		<string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
 		<string>7265231C-39B4-402C-89E1-16167C4CC990</string>
+		<string>F41BD31E-2683-44B8-AE7F-5F09E919790E</string>
 	</array>
 	<key>NSPrincipalClass</key>
 	<string>CedarShortcuts</string>


### PR DESCRIPTION
Allow loading of CedarShortcuts in Xcode 7.2, fixes https://github.com/cppforlife/CedarShortcuts/issues/33